### PR TITLE
refactor: Adjust grid auto rows and gap in globals.css

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -119,8 +119,8 @@ select,
 .grid-auto-columns {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  grid-auto-rows: 400px; /* Set the height of each row to 400px */
-  gap: 1rem; /* Adjust the gap as needed */
+  grid-auto-rows: 450px; /* Set the height of each row to 400px */
+  gap: 2rem; /* Adjust the gap as needed */
   padding: 1rem; /* Adjust the padding as needed */
   overflow-y: auto;
 }

--- a/src/app/home/components/qrcode-list/qrcode-card/index.tsx
+++ b/src/app/home/components/qrcode-list/qrcode-card/index.tsx
@@ -1,6 +1,5 @@
 import { QrCodeContainer } from "~/components/qr-code";
 import {
-  Card,
   CardContent,
   CardDescription,
   CardHeader,
@@ -10,14 +9,14 @@ import { QrCode } from "~/config/qr-code-types";
 
 export const QrCodeCard = ({ qrCode }: { qrCode: QrCode }) => {
   return (
-    <Card className="w-full m-auto h-full rounded-2xl">
+    <section className="w-full bg-card flex-col rounded-2xl">
       <CardHeader>
         <CardTitle>{qrCode.name}</CardTitle>
         <CardDescription>{qrCode.type}</CardDescription>
       </CardHeader>
-      <CardContent className="h-full w-full ">
+      <CardContent>
         <QrCodeContainer code={qrCode.code} />
       </CardContent>
-    </Card>
+    </section>
   );
 };


### PR DESCRIPTION
The code changes in `globals.css` involve adjusting the `grid-auto-rows` property to set the height of each row to 450px instead of 400px. Additionally, the `gap` property has been changed to 2rem instead of 1rem. These modifications aim to improve the layout and spacing of the grid elements, providing a better user experience.

Note: The recent user commits and repository commits have been considered to generate this commit message.