### PR TITLE
Dashboard: real data + per-user data isolation fix

### DIFF
--- a/src/app/(root-layout)/home/dashboard/components/dahboard-scan-location-map.tsx
+++ b/src/app/(root-layout)/home/dashboard/components/dahboard-scan-location-map.tsx
@@ -1,17 +1,65 @@
 "use client";
-import { Globe } from "lucide-react";
 
-// This is a placeholder for a real map component
-// In a real application, you would use a library like react-simple-maps or leaflet
+import { fetchTags } from "@/config/tags";
+import { client } from "@/lib/client";
+import { useQuery } from "@tanstack/react-query";
+import { Globe, MapPin } from "lucide-react";
+
 export function DashboardScanLocationMap() {
+  const { data, isLoading } = useQuery({
+    queryKey: [fetchTags.scanLocations, fetchTags.qrCodeStats],
+    queryFn: async () => {
+      try {
+        const res = await client.qrCode.getScanLocations.$get({ limit: 8 });
+        if (!res.ok) throw new Error("Failed to fetch scan locations");
+        return res.json();
+      } catch (error) {
+        console.error(error);
+        return null;
+      }
+    },
+  });
+
+  if (isLoading)
+    return <div className="h-[250px] w-full animate-pulse rounded-md bg-gray-800" />;
+
+  if (!data || data.total === 0 || data.locations.length === 0)
+    return (
+      <div className="flex h-[250px] flex-col items-center justify-center rounded-lg border border-dashed border-gray-800 bg-gray-950 p-4">
+        <Globe className="mb-2 h-10 w-10 text-gray-500" />
+        <p className="text-center text-sm text-gray-400">
+          No location data yet.
+          <br />
+          Locations appear here once your controlled QR codes are scanned.
+        </p>
+      </div>
+    );
+
+  const max = data.locations[0]?.count || 1;
+
   return (
-    <div className="flex h-[250px] flex-col items-center justify-center rounded-lg border border-dashed border-gray-800 bg-gray-950 p-4">
-      <Globe className="mb-2 h-10 w-10 text-gray-500" />
-      <p className="text-center text-sm text-gray-400">
-        World map showing scan locations would be displayed here.
-        <br />
-        Integrate with a mapping library like react-simple-maps or leaflet.
-      </p>
+    <div className="space-y-3">
+      {data.locations.map((item) => (
+        <div key={item.location} className="flex items-center gap-3">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-gray-800">
+            <MapPin className="h-4 w-4 text-blue-400" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center justify-between gap-2">
+              <p className="truncate text-sm font-medium">{item.location}</p>
+              <span className="shrink-0 text-xs text-gray-400">
+                {item.count} ({item.percent}%)
+              </span>
+            </div>
+            <div className="mt-1 h-2 w-full overflow-hidden rounded-full bg-gray-800">
+              <div
+                className="h-full rounded-full bg-blue-500"
+                style={{ width: `${(item.count / max) * 100}%` }}
+              />
+            </div>
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/app/(root-layout)/home/dashboard/components/dashboaard-recent-scans-table.tsx
+++ b/src/app/(root-layout)/home/dashboard/components/dashboaard-recent-scans-table.tsx
@@ -9,64 +9,30 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { fetchTags } from "@/config/tags";
+import { client } from "@/lib/client";
+import { useQuery } from "@tanstack/react-query";
 import { format } from "date-fns";
 import { Globe, Smartphone } from "lucide-react";
 
-// Mock data for recent scans
-const recentScans = [
-  {
-    id: 1,
-    qrCodeName: "My Portfolio",
-    timestamp: new Date(2025, 3, 5, 14, 32),
-    ip: "192.168.1.1",
-    location: "New York, US",
-    device: "iPhone 15",
-    browser: "Safari",
-    referrer: "Direct",
-  },
-  {
-    id: 2,
-    qrCodeName: "Company Website",
-    timestamp: new Date(2025, 3, 5, 13, 15),
-    ip: "192.168.1.2",
-    location: "London, UK",
-    device: "Samsung Galaxy S23",
-    browser: "Chrome",
-    referrer: "Google",
-  },
-  {
-    id: 3,
-    qrCodeName: "Product Manual",
-    timestamp: new Date(2025, 3, 5, 12, 45),
-    ip: "192.168.1.3",
-    location: "Tokyo, JP",
-    device: "MacBook Pro",
-    browser: "Firefox",
-    referrer: "Direct",
-  },
-  {
-    id: 4,
-    qrCodeName: "Event Registration",
-    timestamp: new Date(2025, 3, 5, 11, 20),
-    ip: "192.168.1.4",
-    location: "Berlin, DE",
-    device: "iPad Pro",
-    browser: "Safari",
-    referrer: "Twitter",
-  },
-  {
-    id: 5,
-    qrCodeName: "My Portfolio",
-    timestamp: new Date(2025, 3, 5, 10, 5),
-    ip: "192.168.1.5",
-    location: "Sydney, AU",
-    device: "Google Pixel 7",
-    browser: "Chrome",
-    referrer: "LinkedIn",
-  },
-];
-
 export function DashboardScansTable() {
+  const { data, isLoading } = useQuery({
+    queryKey: [fetchTags.recentScans, fetchTags.qrCodeControllers],
+    queryFn: async () => {
+      try {
+        const res = await client.qrCode.getRecentScans.$get({ limit: 10 });
+        if (!res.ok) throw new Error("Failed to fetch recent scans");
+        return res.json();
+      } catch (error) {
+        console.error(error);
+        return [];
+      }
+    },
+  });
+
+  if (isLoading)
+    return <div className="h-40 w-full animate-pulse rounded-md bg-gray-800" />;
+
   return (
     <div className="rounded-md border border-gray-800">
       <Table>
@@ -80,31 +46,46 @@ export function DashboardScansTable() {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {recentScans.map((scan) => (
-            <TableRow key={scan.id}>
-              <TableCell className="font-medium">{scan.qrCodeName}</TableCell>
-              <TableCell>{format(scan.timestamp, "MMM d, h:mm a")}</TableCell>
-              <TableCell>
-                <div className="flex items-center gap-1.5">
-                  <Globe className="h-4 w-4 text-gray-400" />
-                  <span>{scan.location}</span>
-                </div>
+          {!data || data.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={5}
+                className="h-24 text-center text-sm text-muted-foreground"
+              >
+                No scans recorded yet
               </TableCell>
-              <TableCell>
-                <div className="flex items-center gap-1.5">
-                  <Smartphone className="h-4 w-4 text-gray-400" />
-                  <span>{scan.device}</span>
-                  <Badge
-                    variant="outline"
-                    className="ml-1 bg-gray-800/50 text-xs"
-                  >
-                    {scan.browser}
-                  </Badge>
-                </div>
-              </TableCell>
-              <TableCell>{scan.referrer}</TableCell>
             </TableRow>
-          ))}
+          ) : (
+            data.map((scan) => (
+              <TableRow key={scan.id}>
+                <TableCell className="font-medium">{scan.qrCodeName}</TableCell>
+                <TableCell>
+                  {format(new Date(scan.timestamp), "MMM d, h:mm a")}
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-1.5">
+                    <Globe className="h-4 w-4 text-gray-400" />
+                    <span>{scan.location}</span>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex items-center gap-1.5">
+                    <Smartphone className="h-4 w-4 text-gray-400" />
+                    <span>{scan.device}</span>
+                    {scan.browser !== "Unknown" && (
+                      <Badge
+                        variant="outline"
+                        className="ml-1 bg-gray-800/50 text-xs"
+                      >
+                        {scan.browser}
+                      </Badge>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell>{scan.referrer}</TableCell>
+              </TableRow>
+            ))
+          )}
         </TableBody>
       </Table>
     </div>

--- a/src/app/(root-layout)/home/dashboard/components/dashboard-grid.tsx
+++ b/src/app/(root-layout)/home/dashboard/components/dashboard-grid.tsx
@@ -11,110 +11,86 @@ import {
 import { formatDistanceToNow } from "date-fns";
 import {
   Copy,
-  Download,
   LinkIcon,
+  Mail,
   MoreHorizontal,
   Pencil,
+  Phone,
   QrCode,
   Smartphone,
   Trash,
   Wifi,
 } from "lucide-react";
-import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import type { DashboardQrCode } from "./dashboard-sectionts/dashboard-qr-codes-section";
 
-// Mock data for QR codes
-const qrCodes = [
-  {
-    id: 1,
-    name: "My Portfolio",
-    type: "url",
-    url: "https://helamanewerton.vercel.app/",
-    createdAt: new Date(2025, 3, 5),
-    scans: 342,
-    image: "/placeholder.svg?height=200&width=200",
-  },
-  {
-    id: 2,
-    name: "Company Website",
-    type: "url",
-    url: "https://example.com",
-    createdAt: new Date(2025, 3, 1),
-    scans: 128,
-    image: "/placeholder.svg?height=200&width=200",
-  },
-  {
-    id: 3,
-    name: "Office WiFi",
-    type: "wifi",
-    url: "SSID: Office Network",
-    createdAt: new Date(2025, 2, 15),
-    scans: 56,
-    image: "/placeholder.svg?height=200&width=200",
-  },
-  {
-    id: 4,
-    name: "Contact Info",
-    type: "text",
-    url: "John Doe, CEO",
-    createdAt: new Date(2025, 2, 10),
-    scans: 89,
-    image: "/placeholder.svg?height=200&width=200",
-  },
-  {
-    id: 5,
-    name: "Product Manual",
-    type: "url",
-    url: "https://docs.example.com/manual",
-    createdAt: new Date(2025, 1, 28),
-    scans: 215,
-    image: "/placeholder.svg?height=200&width=200",
-  },
-  {
-    id: 6,
-    name: "Event Registration",
-    type: "url",
-    url: "https://events.example.com/register",
-    createdAt: new Date(2025, 1, 15),
-    scans: 178,
-    image: "/placeholder.svg?height=200&width=200",
-  },
-];
+const getTypeIcon = (type: string) => {
+  switch (type) {
+    case "link":
+      return <LinkIcon className="h-4 w-4" />;
+    case "wifi":
+      return <Wifi className="h-4 w-4" />;
+    case "email":
+      return <Mail className="h-4 w-4" />;
+    case "phone":
+      return <Phone className="h-4 w-4" />;
+    default:
+      return <QrCode className="h-4 w-4" />;
+  }
+};
 
-export function DashboardGrid() {
+const getTypeColor = (type: string) => {
+  switch (type) {
+    case "link":
+      return "bg-blue-500/10 text-blue-500";
+    case "wifi":
+      return "bg-green-500/10 text-green-500";
+    case "email":
+      return "bg-amber-500/10 text-amber-500";
+    case "phone":
+      return "bg-pink-500/10 text-pink-500";
+    default:
+      return "bg-purple-500/10 text-purple-500";
+  }
+};
+
+export function DashboardGrid({
+  qrCodes,
+  onDelete,
+}: {
+  qrCodes: DashboardQrCode[];
+  onDelete: (id: string) => void;
+}) {
+  if (qrCodes.length === 0)
+    return (
+      <div className="flex h-32 items-center justify-center text-sm text-muted-foreground">
+        No QR codes match your filters
+      </div>
+    );
+
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
       {qrCodes.map((qrCode) => (
-        <QrCodeCard key={qrCode.id} qrCode={qrCode} />
+        <QrCodeCard key={qrCode.id} qrCode={qrCode} onDelete={onDelete} />
       ))}
     </div>
   );
 }
 
-function QrCodeCard({ qrCode }: { qrCode: (typeof qrCodes)[0] }) {
-  const getTypeIcon = (type: string) => {
-    switch (type) {
-      case "url":
-        return <LinkIcon className="h-4 w-4" />;
-      case "wifi":
-        return <Wifi className="h-4 w-4" />;
-      case "text":
-        return <QrCode className="h-4 w-4" />;
-      default:
-        return <QrCode className="h-4 w-4" />;
-    }
-  };
+function QrCodeCard({
+  qrCode,
+  onDelete,
+}: {
+  qrCode: DashboardQrCode;
+  onDelete: (id: string) => void;
+}) {
+  const router = useRouter();
+  const displayUrl = qrCode.link || qrCode.content;
 
-  const getTypeColor = (type: string) => {
-    switch (type) {
-      case "url":
-        return "bg-blue-500/10 text-blue-500";
-      case "wifi":
-        return "bg-green-500/10 text-green-500";
-      case "text":
-        return "bg-purple-500/10 text-purple-500";
-      default:
-        return "bg-gray-500/10 text-gray-500";
-    }
+  const copyLink = () => {
+    navigator.clipboard.writeText(displayUrl);
+    toast.success("Copied to clipboard");
   };
 
   return (
@@ -128,20 +104,21 @@ function QrCodeCard({ qrCode }: { qrCode: (typeof qrCodes)[0] }) {
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={() => router.push(`/home/qr-code/${qrCode.uuid}`)}
+            >
               <Pencil className="mr-2 h-4 w-4" />
               Edit
             </DropdownMenuItem>
-            <DropdownMenuItem>
+            <DropdownMenuItem onClick={copyLink}>
               <Copy className="mr-2 h-4 w-4" />
-              Duplicate
-            </DropdownMenuItem>
-            <DropdownMenuItem>
-              <Download className="mr-2 h-4 w-4" />
-              Download
+              Copy link
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem className="text-red-500">
+            <DropdownMenuItem
+              className="text-red-500"
+              onClick={() => onDelete(qrCode.id)}
+            >
               <Trash className="mr-2 h-4 w-4" />
               Delete
             </DropdownMenuItem>
@@ -155,27 +132,29 @@ function QrCodeCard({ qrCode }: { qrCode: (typeof qrCodes)[0] }) {
             <span className="ml-1 capitalize">{qrCode.type}</span>
           </Badge>
           <span className="text-xs text-gray-400">
-            {formatDistanceToNow(qrCode.createdAt, { addSuffix: true })}
+            {formatDistanceToNow(new Date(qrCode.createdAt), {
+              addSuffix: true,
+            })}
           </span>
         </div>
         <h3 className="mb-1 text-lg font-medium">{qrCode.name}</h3>
-        <p className="mb-4 truncate text-sm text-gray-400">{qrCode.url}</p>
+        <p className="mb-4 truncate text-sm text-gray-400">{displayUrl}</p>
         <div className="flex justify-center">
-          <div className="relative h-32 w-32 overflow-hidden rounded-md bg-white p-2">
-            <Image
-              src={qrCode.image || "/placeholder.svg"}
-              alt={qrCode.name}
-              fill
-              className="object-contain"
-            />
+          <div className="flex h-32 w-32 items-center justify-center rounded-md bg-white">
+            <QrCode className="h-20 w-20 text-gray-900" />
           </div>
         </div>
         <div className="mt-4 flex items-center justify-between">
           <div className="flex items-center gap-1 text-sm">
             <Smartphone className="h-4 w-4 text-gray-400" />
-            <span>{qrCode.scans.toLocaleString()} scans</span>
+            <span>{qrCode.scanCount.toLocaleString()} scans</span>
           </div>
-          <Button variant="ghost" size="sm" className="h-8 gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-8 gap-1"
+            onClick={copyLink}
+          >
             <LinkIcon className="h-3 w-3" />
             Link
           </Button>

--- a/src/app/(root-layout)/home/dashboard/components/dashboard-list.tsx
+++ b/src/app/(root-layout)/home/dashboard/components/dashboard-list.tsx
@@ -19,101 +19,63 @@ import {
 } from "@/components/ui/table";
 import { format } from "date-fns";
 import {
-  BarChart2,
   Copy,
-  Download,
   Link,
+  Mail,
   MoreHorizontal,
   Pencil,
+  Phone,
   QrCode,
   Smartphone,
   Trash,
   Wifi,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import type { DashboardQrCode } from "./dashboard-sectionts/dashboard-qr-codes-section";
 
-// Mock data for QR codes (same as in QrCodeGrid)
-const qrCodes = [
-  {
-    id: 1,
-    name: "My Portfolio",
-    type: "url",
-    url: "https://helamanewerton.vercel.app/",
-    createdAt: new Date(2025, 3, 5),
-    scans: 342,
-    image: "/placeholder.svg?height=200&width=200",
-  },
-  {
-    id: 2,
-    name: "Company Website",
-    type: "url",
-    url: "https://example.com",
-    createdAt: new Date(2025, 3, 1),
-    scans: 128,
-    image: "/placeholder.svg?height=200&width=200",
-  },
-  {
-    id: 3,
-    name: "Office WiFi",
-    type: "wifi",
-    url: "SSID: Office Network",
-    createdAt: new Date(2025, 2, 15),
-    scans: 56,
-    image: "/placeholder.svg?height=200&width=200",
-  },
-  {
-    id: 4,
-    name: "Contact Info",
-    type: "text",
-    url: "John Doe, CEO",
-    createdAt: new Date(2025, 2, 10),
-    scans: 89,
-    image: "/placeholder.svg?height=200&width=200",
-  },
-  {
-    id: 5,
-    name: "Product Manual",
-    type: "url",
-    url: "https://docs.example.com/manual",
-    createdAt: new Date(2025, 1, 28),
-    scans: 215,
-    image: "/placeholder.svg?height=200&width=200",
-  },
-  {
-    id: 6,
-    name: "Event Registration",
-    type: "url",
-    url: "https://events.example.com/register",
-    createdAt: new Date(2025, 1, 15),
-    scans: 178,
-    image: "/placeholder.svg?height=200&width=200",
-  },
-];
+const getTypeIcon = (type: string) => {
+  switch (type) {
+    case "link":
+      return <Link className="h-4 w-4" />;
+    case "wifi":
+      return <Wifi className="h-4 w-4" />;
+    case "email":
+      return <Mail className="h-4 w-4" />;
+    case "phone":
+      return <Phone className="h-4 w-4" />;
+    default:
+      return <QrCode className="h-4 w-4" />;
+  }
+};
 
-export function DashboardList() {
-  const getTypeIcon = (type: string) => {
-    switch (type) {
-      case "url":
-        return <Link className="h-4 w-4" />;
-      case "wifi":
-        return <Wifi className="h-4 w-4" />;
-      case "text":
-        return <QrCode className="h-4 w-4" />;
-      default:
-        return <QrCode className="h-4 w-4" />;
-    }
-  };
+const getTypeColor = (type: string) => {
+  switch (type) {
+    case "link":
+      return "bg-blue-500/10 text-blue-500";
+    case "wifi":
+      return "bg-green-500/10 text-green-500";
+    case "email":
+      return "bg-amber-500/10 text-amber-500";
+    case "phone":
+      return "bg-pink-500/10 text-pink-500";
+    default:
+      return "bg-purple-500/10 text-purple-500";
+  }
+};
 
-  const getTypeColor = (type: string) => {
-    switch (type) {
-      case "url":
-        return "bg-blue-500/10 text-blue-500";
-      case "wifi":
-        return "bg-green-500/10 text-green-500";
-      case "text":
-        return "bg-purple-500/10 text-purple-500";
-      default:
-        return "bg-gray-500/10 text-gray-500";
-    }
+export function DashboardList({
+  qrCodes,
+  onDelete,
+}: {
+  qrCodes: DashboardQrCode[];
+  onDelete: (id: string) => void;
+}) {
+  const router = useRouter();
+
+  const copyLink = (value: string) => {
+    navigator.clipboard.writeText(value);
+    toast.success("Copied to clipboard");
   };
 
   return (
@@ -129,75 +91,102 @@ export function DashboardList() {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {qrCodes.map((qrCode) => (
-            <TableRow key={qrCode.id}>
-              <TableCell className="font-medium">
-                <div className="flex items-center gap-2">
-                  <div className="flex h-8 w-8 items-center justify-center rounded bg-gray-800">
-                    <QrCode className="h-4 w-4" />
-                  </div>
-                  <div>
-                    <div>{qrCode.name}</div>
-                    <div className="truncate text-xs text-gray-400 max-w-[200px]">
-                      {qrCode.url}
-                    </div>
-                  </div>
-                </div>
-              </TableCell>
-              <TableCell>
-                <Badge variant="outline" className={getTypeColor(qrCode.type)}>
-                  {getTypeIcon(qrCode.type)}
-                  <span className="ml-1 capitalize">{qrCode.type}</span>
-                </Badge>
-              </TableCell>
-              <TableCell>{format(qrCode.createdAt, "MMM d, yyyy")}</TableCell>
-              <TableCell>
-                <div className="flex items-center gap-1">
-                  <Smartphone className="h-4 w-4 text-gray-400" />
-                  <span>{qrCode.scans.toLocaleString()}</span>
-                </div>
-              </TableCell>
-              <TableCell className="text-right">
-                <div className="flex items-center justify-end gap-2">
-                  <Button variant="ghost" size="icon" className="h-8 w-8">
-                    <BarChart2 className="h-4 w-4" />
-                    <span className="sr-only">View analytics</span>
-                  </Button>
-                  <Button variant="ghost" size="icon" className="h-8 w-8">
-                    <Link className="h-4 w-4" />
-                    <span className="sr-only">Copy link</span>
-                  </Button>
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="icon" className="h-8 w-8">
-                        <MoreHorizontal className="h-4 w-4" />
-                        <span className="sr-only">Open menu</span>
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem>
-                        <Pencil className="mr-2 h-4 w-4" />
-                        Edit
-                      </DropdownMenuItem>
-                      <DropdownMenuItem>
-                        <Copy className="mr-2 h-4 w-4" />
-                        Duplicate
-                      </DropdownMenuItem>
-                      <DropdownMenuItem>
-                        <Download className="mr-2 h-4 w-4" />
-                        Download
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem className="text-red-500">
-                        <Trash className="mr-2 h-4 w-4" />
-                        Delete
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </div>
+          {qrCodes.length === 0 ? (
+            <TableRow>
+              <TableCell
+                colSpan={5}
+                className="h-24 text-center text-sm text-muted-foreground"
+              >
+                No QR codes match your filters
               </TableCell>
             </TableRow>
-          ))}
+          ) : (
+            qrCodes.map((qrCode) => {
+              const displayUrl = qrCode.link || qrCode.content;
+              return (
+                <TableRow key={qrCode.id}>
+                  <TableCell className="font-medium">
+                    <div className="flex items-center gap-2">
+                      <div className="flex h-8 w-8 items-center justify-center rounded bg-gray-800">
+                        <QrCode className="h-4 w-4" />
+                      </div>
+                      <div>
+                        <div>{qrCode.name}</div>
+                        <div className="max-w-[200px] truncate text-xs text-gray-400">
+                          {displayUrl}
+                        </div>
+                      </div>
+                    </div>
+                  </TableCell>
+                  <TableCell>
+                    <Badge
+                      variant="outline"
+                      className={getTypeColor(qrCode.type)}
+                    >
+                      {getTypeIcon(qrCode.type)}
+                      <span className="ml-1 capitalize">{qrCode.type}</span>
+                    </Badge>
+                  </TableCell>
+                  <TableCell>
+                    {format(new Date(qrCode.createdAt), "MMM d, yyyy")}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex items-center gap-1">
+                      <Smartphone className="h-4 w-4 text-gray-400" />
+                      <span>{qrCode.scanCount.toLocaleString()}</span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => copyLink(displayUrl)}
+                      >
+                        <Link className="h-4 w-4" />
+                        <span className="sr-only">Copy link</span>
+                      </Button>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                          >
+                            <MoreHorizontal className="h-4 w-4" />
+                            <span className="sr-only">Open menu</span>
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuItem
+                            onClick={() =>
+                              router.push(`/home/qr-code/${qrCode.uuid}`)
+                            }
+                          >
+                            <Pencil className="mr-2 h-4 w-4" />
+                            Edit
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => copyLink(displayUrl)}>
+                            <Copy className="mr-2 h-4 w-4" />
+                            Copy link
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            className="text-red-500"
+                            onClick={() => onDelete(qrCode.id)}
+                          >
+                            <Trash className="mr-2 h-4 w-4" />
+                            Delete
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              );
+            })
+          )}
         </TableBody>
       </Table>
     </div>

--- a/src/app/(root-layout)/home/dashboard/components/dashboard-scan-activity-chart.tsx
+++ b/src/app/(root-layout)/home/dashboard/components/dashboard-scan-activity-chart.tsx
@@ -12,13 +12,23 @@ import {
   YAxis,
 } from "recharts";
 
-export function DashboardScanActivityChart() {
+export type ScanActivityFilter =
+  | "7_DAYS"
+  | "30_DAYS"
+  | "90_DAYS"
+  | "LAST_YEAR";
+
+export function DashboardScanActivityChart({
+  filter = "30_DAYS",
+}: {
+  filter?: ScanActivityFilter;
+}) {
   const { data, isLoading } = useQuery({
-    queryKey: [fetchTags.qrCodeScans, fetchTags.qrCodeStats],
+    queryKey: [fetchTags.qrCodeScans, fetchTags.qrCodeStats, filter],
     queryFn: async () => {
       try {
         const res = await client.qrCode.getQrCodesScans.$get({
-          filter: "LAST_YEAR",
+          filter,
         });
         if (!res.ok) throw new Error("Failed to fetch QR code stats");
         return res.json();
@@ -26,7 +36,7 @@ export function DashboardScanActivityChart() {
         console.error(error);
         return [];
       }
-    },  
+    },
   });
 
   if (!data)
@@ -53,7 +63,9 @@ export function DashboardScanActivityChart() {
             fontSize={12}
             tickLine={false}
             axisLine={false}
-            tickFormatter={(value) => value.split(" ")[1]}
+            tickFormatter={(value) =>
+              value.includes(" ") ? value.split(" ")[1] : value
+            }
           />
           <YAxis
             stroke="#888888"

--- a/src/app/(root-layout)/home/dashboard/components/dashboard-sectionts/dashboard-qr-codes-section.tsx
+++ b/src/app/(root-layout)/home/dashboard/components/dashboard-sectionts/dashboard-qr-codes-section.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { fetchTags } from "@/config/tags";
+import { client } from "@/lib/client";
+import { useQuery } from "@tanstack/react-query";
+import { Download, Search } from "lucide-react";
+import { useMemo, useState } from "react";
+import { DeleteQrCodeDialog } from "../../../components/qr-code-display/delete-qr-code-dialog";
+import { DashboardGrid } from "../dashboard-grid";
+import { DashboardList } from "../dashboard-list";
+
+export interface DashboardQrCode {
+  id: string;
+  uuid: string;
+  name: string;
+  type: "link" | "text" | "email" | "phone" | "wifi";
+  content: string;
+  link: string | null;
+  isControlled: boolean | null;
+  createdAt: Date | string;
+  scanCount: number;
+}
+
+const escapeCsv = (value: string) => `"${value.replace(/"/g, '""')}"`;
+
+export function DashboardQrCodesSection() {
+  const [search, setSearch] = useState("");
+  const [typeFilter, setTypeFilter] = useState("all");
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery({
+    // Prefixed with fetchTags.qrCodes so the shared delete dialog's
+    // invalidation (which targets the "qr-codes" prefix) also refreshes us.
+    queryKey: [fetchTags.qrCodes, fetchTags.qrCodesWithScans],
+    queryFn: async () => {
+      try {
+        const res = await client.qrCode.getQrCodesWithScans.$get();
+        if (!res.ok) throw new Error("Failed to fetch QR codes");
+        return res.json();
+      } catch (error) {
+        console.error(error);
+        return [];
+      }
+    },
+  });
+
+  const filtered = useMemo(() => {
+    const list = (data ?? []) as DashboardQrCode[];
+    const query = search.trim().toLowerCase();
+    return list.filter((qrCode) => {
+      const matchesType = typeFilter === "all" || qrCode.type === typeFilter;
+      const matchesSearch =
+        query.length === 0 ||
+        qrCode.name.toLowerCase().includes(query) ||
+        (qrCode.link ?? qrCode.content).toLowerCase().includes(query);
+      return matchesType && matchesSearch;
+    });
+  }, [data, search, typeFilter]);
+
+  const handleExport = () => {
+    const header = ["Name", "Type", "URL", "Scans", "Created"];
+    const rows = filtered.map((qrCode) =>
+      [
+        qrCode.name,
+        qrCode.type,
+        qrCode.link || qrCode.content,
+        String(qrCode.scanCount),
+        new Date(qrCode.createdAt).toISOString(),
+      ]
+        .map(escapeCsv)
+        .join(",")
+    );
+    const csv = [header.map(escapeCsv).join(","), ...rows].join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "qr-codes.csv";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+          <div>
+            <CardTitle>Your QR Codes</CardTitle>
+            <CardDescription>Manage and track all your QR codes</CardDescription>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <Select value={typeFilter} onValueChange={setTypeFilter}>
+              <SelectTrigger className="w-36">
+                <SelectValue placeholder="QR Code Type" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="all">All Types</SelectItem>
+                <SelectItem value="text">Text</SelectItem>
+                <SelectItem value="link">Link</SelectItem>
+                <SelectItem value="wifi">WiFi</SelectItem>
+                <SelectItem value="email">Email</SelectItem>
+                <SelectItem value="phone">Phone</SelectItem>
+              </SelectContent>
+            </Select>
+            <div className="relative flex-1 md:min-w-[200px]">
+              <Search className="absolute left-2 top-2.5 h-4 w-4 text-gray-400" />
+              <Input
+                placeholder="Search QR codes..."
+                className="pl-8"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+              />
+            </div>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="h-40 w-full animate-pulse rounded-md bg-gray-800" />
+        ) : (
+          <Tabs defaultValue="grid">
+            <div className="mb-4 flex items-center justify-between">
+              <TabsList>
+                <TabsTrigger value="grid">Grid</TabsTrigger>
+                <TabsTrigger value="list">List</TabsTrigger>
+              </TabsList>
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-1"
+                onClick={handleExport}
+                disabled={filtered.length === 0}
+              >
+                <Download className="h-4 w-4" />
+                Export
+              </Button>
+            </div>
+            <TabsContent value="grid">
+              <DashboardGrid qrCodes={filtered} onDelete={setDeleteId} />
+            </TabsContent>
+            <TabsContent value="list">
+              <DashboardList qrCodes={filtered} onDelete={setDeleteId} />
+            </TabsContent>
+          </Tabs>
+        )}
+      </CardContent>
+
+      <DeleteQrCodeDialog
+        qrCodeId={deleteId ?? ""}
+        open={deleteId !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteId(null);
+        }}
+      />
+    </Card>
+  );
+}

--- a/src/app/(root-layout)/home/dashboard/components/dashboard-sectionts/dashboard-scans-sections.tsx
+++ b/src/app/(root-layout)/home/dashboard/components/dashboard-sectionts/dashboard-scans-sections.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   Card,
   CardContent,
@@ -13,10 +15,22 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-import { Suspense } from "react";
-import { DashboardScanActivityChart } from "../dashboard-scan-activity-chart";
+import { Suspense, useState } from "react";
+import {
+  DashboardScanActivityChart,
+  type ScanActivityFilter,
+} from "../dashboard-scan-activity-chart";
+
+const periodToFilter: Record<string, ScanActivityFilter> = {
+  "7days": "7_DAYS",
+  "30days": "30_DAYS",
+  "90days": "90_DAYS",
+  year: "LAST_YEAR",
+};
 
 export const DashboardScansSection = () => {
+  const [period, setPeriod] = useState("30days");
+
   return (
     <Card className="col-span-full lg:col-span-2">
       <CardHeader className="flex flex-row items-center justify-between">
@@ -24,7 +38,7 @@ export const DashboardScansSection = () => {
           <CardTitle>Scan Activity</CardTitle>
           <CardDescription>QR code scans over time</CardDescription>
         </div>
-        <Select defaultValue="30days">
+        <Select value={period} onValueChange={setPeriod}>
           <SelectTrigger className="w-36">
             <SelectValue placeholder="Select period" />
           </SelectTrigger>
@@ -42,7 +56,7 @@ export const DashboardScansSection = () => {
             <div className="h-10 w-full animate-pulse rounded-md bg-gray-800" />
           }
         >
-          <DashboardScanActivityChart />
+          <DashboardScanActivityChart filter={periodToFilter[period]} />
         </Suspense>
       </CardContent>
     </Card>

--- a/src/app/(root-layout)/home/dashboard/components/dashboard-usage-chart.tsx
+++ b/src/app/(root-layout)/home/dashboard/components/dashboard-usage-chart.tsx
@@ -1,23 +1,60 @@
 "use client";
 
+import { fetchTags } from "@/config/tags";
+import { client } from "@/lib/client";
+import { useQuery } from "@tanstack/react-query";
 import { Laptop, Smartphone, Tablet } from "lucide-react";
 import { Cell, Pie, PieChart, ResponsiveContainer, Tooltip } from "recharts";
 
-// Mock data for device usage
-const data = [
-  { name: "Mobile", value: 65, color: "#3b82f6", icon: Smartphone },
-  { name: "Desktop", value: 25, color: "#10b981", icon: Laptop },
-  { name: "Tablet", value: 10, color: "#f59e0b", icon: Tablet },
-];
+const deviceMeta: Record<
+  string,
+  { color: string; icon: typeof Smartphone }
+> = {
+  Mobile: { color: "#3b82f6", icon: Smartphone },
+  Desktop: { color: "#10b981", icon: Laptop },
+  Tablet: { color: "#f59e0b", icon: Tablet },
+};
 
 export function DashboardUsageChart() {
+  const { data, isLoading } = useQuery({
+    queryKey: [fetchTags.deviceUsage, fetchTags.qrCodeStats],
+    queryFn: async () => {
+      try {
+        const res = await client.qrCode.getDeviceUsage.$get();
+        if (!res.ok) throw new Error("Failed to fetch device usage");
+        return res.json();
+      } catch (error) {
+        console.error(error);
+        return null;
+      }
+    },
+  });
+
+  if (isLoading)
+    return <div className="h-[240px] w-full animate-pulse rounded-md bg-gray-800" />;
+
+  if (!data || data.total === 0)
+    return (
+      <div className="flex h-[240px] w-full items-center justify-center">
+        <p className="text-sm text-muted-foreground">No scan data yet</p>
+      </div>
+    );
+
+  const chartData = data.usage
+    .filter((item) => item.count > 0)
+    .map((item) => ({
+      ...item,
+      color: deviceMeta[item.name]?.color ?? "#6b7280",
+      icon: deviceMeta[item.name]?.icon ?? Smartphone,
+    }));
+
   return (
     <div className="flex flex-col items-center">
       <div className="h-[200px] w-full">
         <ResponsiveContainer width="100%" height="100%">
           <PieChart>
             <Pie
-              data={data}
+              data={chartData}
               cx="50%"
               cy="50%"
               innerRadius={60}
@@ -25,7 +62,7 @@ export function DashboardUsageChart() {
               paddingAngle={2}
               dataKey="value"
             >
-              {data.map((entry, index) => (
+              {chartData.map((entry, index) => (
                 <Cell key={`cell-${index}`} fill={entry.color} />
               ))}
             </Pie>
@@ -62,8 +99,8 @@ export function DashboardUsageChart() {
           </PieChart>
         </ResponsiveContainer>
       </div>
-      <div className="mt-4 flex justify-center gap-4">
-        {data.map((item, index) => {
+      <div className="mt-4 flex flex-wrap justify-center gap-4">
+        {chartData.map((item, index) => {
           const Icon = item.icon;
           return (
             <div key={index} className="flex items-center gap-1.5">

--- a/src/app/(root-layout)/home/dashboard/page.tsx
+++ b/src/app/(root-layout)/home/dashboard/page.tsx
@@ -1,7 +1,5 @@
 // Project: qr-code-generator
 
-import { DatePickerWithRange } from "@/components/date-range-picker";
-
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -10,22 +8,12 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 
-import { Download, Filter, Plus, Search } from "lucide-react";
+import { Plus } from "lucide-react";
 import Link from "next/link";
 import { DashboardScanLocationMap } from "./components/dahboard-scan-location-map";
 import { DashboardScansTable } from "./components/dashboaard-recent-scans-table";
-import { DashboardGrid } from "./components/dashboard-grid";
-import { DashboardList } from "./components/dashboard-list";
+import { DashboardQrCodesSection } from "./components/dashboard-sectionts/dashboard-qr-codes-section";
 import { DashboardScansSection } from "./components/dashboard-sectionts/dashboard-scans-sections";
 import { DashboardStatsSection } from "./components/dashboard-sectionts/dashboard-stats-section";
 import { DashboardTopQrCodes } from "./components/dashboard-top-qr-codes";
@@ -83,65 +71,7 @@ export default function DashboardPage() {
         </Card>
       </div>
 
-      <Card>
-        <CardHeader>
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div>
-              <CardTitle>Your QR Codes</CardTitle>
-              <CardDescription>
-                Manage and track all your QR codes
-              </CardDescription>
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <div className="flex items-center gap-2">
-                <Select defaultValue="all">
-                  <SelectTrigger className="w-36">
-                    <SelectValue placeholder="QR Code Type" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All Types</SelectItem>
-                    <SelectItem value="text">Text</SelectItem>
-                    <SelectItem value="url">URL</SelectItem>
-                    <SelectItem value="wifi">WiFi</SelectItem>
-                    <SelectItem value="email">Email</SelectItem>
-                    <SelectItem value="phone">Phone</SelectItem>
-                  </SelectContent>
-                </Select>
-                <DatePickerWithRange
-                  date={{ to: new Date(), from: new Date() }}
-                />
-                <Button variant="outline" size="icon">
-                  <Filter className="h-4 w-4" />
-                </Button>
-              </div>
-              <div className="relative flex-1 md:min-w-[200px]">
-                <Search className="absolute left-2 top-2.5 h-4 w-4 text-gray-400" />
-                <Input placeholder="Search QR codes..." className="pl-8" />
-              </div>
-            </div>
-          </div>
-        </CardHeader>
-        <CardContent>
-          <Tabs defaultValue="grid">
-            <div className="mb-4 flex items-center justify-between">
-              <TabsList>
-                <TabsTrigger value="grid">Grid</TabsTrigger>
-                <TabsTrigger value="list">List</TabsTrigger>
-              </TabsList>
-              <Button variant="outline" size="sm" className="gap-1">
-                <Download className="h-4 w-4" />
-                Export
-              </Button>
-            </div>
-            <TabsContent value="grid">
-              <DashboardGrid />
-            </TabsContent>
-            <TabsContent value="list">
-              <DashboardList />
-            </TabsContent>
-          </Tabs>
-        </CardContent>
-      </Card>
+      <DashboardQrCodesSection />
 
       <Card className="mt-6">
         <CardHeader>

--- a/src/config/tags.ts
+++ b/src/config/tags.ts
@@ -8,4 +8,8 @@ export const fetchTags = {
   qrCodeStats: "qr-code-stats",
   topQrCodes: "top-qr-codes",
   qrCodeScans: "qr-code-scans",
+  qrCodesWithScans: "qr-codes-with-scans",
+  recentScans: "recent-scans",
+  deviceUsage: "device-usage",
+  scanLocations: "scan-locations",
 };

--- a/src/server/jstack.ts
+++ b/src/server/jstack.ts
@@ -32,13 +32,17 @@ const authMiddleware = j.middleware(async ({ c, next }) => {
     headers: await headers(),
   });
 
-  if (!session || !session.session) {
+  // Require a resolved user id. Without this guard a missing `user.id` would
+  // flow into Prisma `where: { userId: undefined }` clauses, which Prisma
+  // treats as "no filter" and would leak every user's rows. Failing closed
+  // here keeps all downstream queries scoped to the authenticated user.
+  if (!session || !session.session || !session.user?.id) {
     throw new HTTPException(401, {
       message: "Unauthorized, sign in to continue.",
     });
   }
 
-  return await next({ auth: { session } });
+  return await next({ auth: { session, userId: session.user.id } });
 });
 
 /**

--- a/src/server/routers/controller-router.ts
+++ b/src/server/routers/controller-router.ts
@@ -86,19 +86,23 @@ export const controlledRouter = j.router({
   delete: privateProcedure
     .input(z.object({ id: z.string() }))
     .mutation(async ({ ctx, c, input }) => {
-      const { db } = ctx;
-      const deletedQrCode = await db.qrCodeController.delete({
+      const { db, auth } = ctx;
+
+      // deleteMany lets us scope by the owning qrCode's userId so a user can
+      // only ever delete their own scan records. count === 0 means the record
+      // either doesn't exist or isn't owned by this user.
+      const deleted = await db.qrCodeController.deleteMany({
         where: {
           id: input.id,
           qrCode: {
-            userId: (input.id, input.id)!,
+            userId: auth.session.user.id,
           },
         },
       });
-      if (!deletedQrCode) {
+      if (deleted.count === 0) {
         throw new Error("QrCode not found");
       }
 
-      return c.superjson(deletedQrCode);
+      return c.superjson({ id: input.id, deleted: deleted.count });
     }),
 });

--- a/src/server/routers/qr-code-router.ts
+++ b/src/server/routers/qr-code-router.ts
@@ -2,6 +2,12 @@ import { env } from "hono/adapter";
 import uniqolor from "uniqolor";
 import { v4 as uuidv4 } from "uuid";
 import { z } from "zod";
+import {
+  type DeviceType,
+  formatReferrer,
+  localeToCountry,
+  parseUserAgent,
+} from "@/utils/scan-analytics.utils";
 import { updateQrCodeInputSchema } from "../db/qr-code-schema.utils";
 import { j, privateProcedure, publicProcedure } from "../jstack";
 
@@ -253,10 +259,15 @@ export const qrCodeRouter = j.router({
       now.getMonth() - 1,
       now.getDate()
     );
-    const startOfThisWeek = new Date(now.setDate(now.getDate() - now.getDay()));
-    const endOfThisWeek = new Date(
-      now.setDate(now.getDate() - now.getDay() + 6)
-    );
+    // Compute the week bounds on copies so we don't mutate `now` (the original
+    // code called now.setDate(...) twice, shifting `now` into the future and
+    // corrupting every `createdAt < now` comparison below).
+    const startOfThisWeek = new Date(now);
+    startOfThisWeek.setDate(now.getDate() - now.getDay());
+    startOfThisWeek.setHours(0, 0, 0, 0);
+    const endOfThisWeek = new Date(startOfThisWeek);
+    endOfThisWeek.setDate(startOfThisWeek.getDate() + 6);
+    endOfThisWeek.setHours(23, 59, 59, 999);
 
     // Get all stats in a single query using Prisma's aggregation
     const [
@@ -453,5 +464,173 @@ export const qrCodeRouter = j.router({
       );
 
       return c.superjson(formattedScans);
+    }),
+
+  // All of the user's QR codes plus their scan counts, for the dashboard
+  // "Your QR Codes" grid/list.
+  getQrCodesWithScans: privateProcedure.query(async ({ ctx, c }) => {
+    const { db, auth } = ctx;
+    const userId = auth?.session?.user.id!;
+
+    const qrCodes = await db.qRCode.findMany({
+      where: {
+        userId,
+        deletedAt: null,
+      },
+      select: {
+        id: true,
+        uuid: true,
+        name: true,
+        type: true,
+        content: true,
+        link: true,
+        isControlled: true,
+        createdAt: true,
+        _count: {
+          select: {
+            qrCodeControllers: true,
+          },
+        },
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+
+    const result = qrCodes.map((qrCode) => ({
+      id: qrCode.id,
+      uuid: qrCode.uuid,
+      name: qrCode.name,
+      type: qrCode.type,
+      content: qrCode.content,
+      link: qrCode.link,
+      isControlled: qrCode.isControlled,
+      createdAt: qrCode.createdAt,
+      scanCount: qrCode._count.qrCodeControllers,
+    }));
+
+    return c.superjson(result);
+  }),
+
+  // Latest scans across all of the user's QR codes, with device / location /
+  // referrer derived from the captured headers.
+  getRecentScans: privateProcedure
+    .input(
+      z.object({
+        limit: z.number().min(1).max(100).optional().default(10),
+      })
+    )
+    .query(async ({ ctx, c, input }) => {
+      const { db, auth } = ctx;
+      const userId = auth?.session?.user.id!;
+
+      const scans = await db.qrCodeController.findMany({
+        where: {
+          qrCode: { userId },
+        },
+        orderBy: {
+          createdAt: "desc",
+        },
+        take: input.limit,
+        select: {
+          id: true,
+          createdAt: true,
+          ip: true,
+          ip2: true,
+          userAgent: true,
+          locale: true,
+          referrer: true,
+          qrCode: {
+            select: { name: true },
+          },
+        },
+      });
+
+      const recentScans = scans.map((scan) => {
+        const { deviceType, os, browser } = parseUserAgent(scan.userAgent);
+        return {
+          id: scan.id,
+          qrCodeName: scan.qrCode?.name ?? "Unknown",
+          timestamp: scan.createdAt,
+          ip: scan.ip || scan.ip2 || "-",
+          location: localeToCountry(scan.locale),
+          device: os !== "Unknown" ? os : deviceType,
+          browser,
+          referrer: formatReferrer(scan.referrer),
+        };
+      });
+
+      return c.superjson(recentScans);
+    }),
+
+  // Scans grouped by device type (Mobile / Desktop / Tablet) for the
+  // "Device Usage" chart.
+  getDeviceUsage: privateProcedure.query(async ({ ctx, c }) => {
+    const { db, auth } = ctx;
+    const userId = auth?.session?.user.id!;
+
+    const scans = await db.qrCodeController.findMany({
+      where: {
+        qrCode: { userId },
+      },
+      select: { userAgent: true },
+    });
+
+    const counts: Record<DeviceType, number> = {
+      Mobile: 0,
+      Desktop: 0,
+      Tablet: 0,
+    };
+    for (const scan of scans) {
+      counts[parseUserAgent(scan.userAgent).deviceType]++;
+    }
+
+    const total = scans.length;
+    const order: DeviceType[] = ["Mobile", "Desktop", "Tablet"];
+    const usage = order.map((name) => ({
+      name,
+      count: counts[name],
+      value: total > 0 ? Math.round((counts[name] / total) * 100) : 0,
+    }));
+
+    return c.superjson({ total, usage });
+  }),
+
+  // Scans grouped by country (derived from the accept-language header) for the
+  // "Scan Locations" panel.
+  getScanLocations: privateProcedure
+    .input(
+      z.object({
+        limit: z.number().min(1).max(50).optional().default(8),
+      })
+    )
+    .query(async ({ ctx, c, input }) => {
+      const { db, auth } = ctx;
+      const userId = auth?.session?.user.id!;
+
+      const scans = await db.qrCodeController.findMany({
+        where: {
+          qrCode: { userId },
+        },
+        select: { locale: true },
+      });
+
+      const counts = new Map<string, number>();
+      for (const scan of scans) {
+        const country = localeToCountry(scan.locale);
+        counts.set(country, (counts.get(country) ?? 0) + 1);
+      }
+
+      const total = scans.length;
+      const locations = Array.from(counts.entries())
+        .map(([location, count]) => ({
+          location,
+          count,
+          percent: total > 0 ? Math.round((count / total) * 100) : 0,
+        }))
+        .sort((a, b) => b.count - a.count)
+        .slice(0, input.limit);
+
+      return c.superjson({ total, locations });
     }),
 });

--- a/src/utils/scan-analytics.utils.ts
+++ b/src/utils/scan-analytics.utils.ts
@@ -1,0 +1,95 @@
+// Server-side helpers to derive analytics from raw QrCodeController fields
+// (user-agent + accept-language headers captured on each controlled scan).
+
+export type DeviceType = "Mobile" | "Tablet" | "Desktop";
+
+export interface ParsedUserAgent {
+  deviceType: DeviceType;
+  os: string;
+  browser: string;
+}
+
+/**
+ * Lightweight, dependency-free user-agent parser. It only needs to be good
+ * enough to bucket scans by device type / OS / browser for the dashboard.
+ */
+export const parseUserAgent = (userAgent: string | null | undefined): ParsedUserAgent => {
+  const ua = userAgent ?? "";
+
+  const isTablet = /ipad|tablet|playbook|silk|(android(?!.*mobile))/i.test(ua);
+  const isMobile =
+    !isTablet &&
+    /mobi|iphone|ipod|android.*mobile|windows phone|blackberry|bb10|opera mini/i.test(
+      ua
+    );
+  const deviceType: DeviceType = isTablet
+    ? "Tablet"
+    : isMobile
+    ? "Mobile"
+    : "Desktop";
+
+  const os = (() => {
+    if (/windows phone/i.test(ua)) return "Windows Phone";
+    if (/windows/i.test(ua)) return "Windows";
+    if (/iphone|ipad|ipod/i.test(ua)) return "iOS";
+    if (/android/i.test(ua)) return "Android";
+    if (/mac os x|macintosh/i.test(ua)) return "macOS";
+    if (/cros/i.test(ua)) return "ChromeOS";
+    if (/linux/i.test(ua)) return "Linux";
+    return "Unknown";
+  })();
+
+  const browser = (() => {
+    if (/edg(e|a|ios)?\//i.test(ua)) return "Edge";
+    if (/opr\/|opera/i.test(ua)) return "Opera";
+    if (/samsungbrowser/i.test(ua)) return "Samsung Internet";
+    if (/firefox|fxios/i.test(ua)) return "Firefox";
+    if (/chrome|crios|chromium/i.test(ua)) return "Chrome";
+    if (/safari/i.test(ua)) return "Safari";
+    return "Unknown";
+  })();
+
+  return { deviceType, os, browser };
+};
+
+let regionDisplay: Intl.DisplayNames | null = null;
+try {
+  regionDisplay = new Intl.DisplayNames(["en"], { type: "region" });
+} catch {
+  regionDisplay = null;
+}
+
+/**
+ * Turn an Accept-Language value (e.g. "en-US,en;q=0.9,pt;q=0.8") into a human
+ * readable country name. Returns "Unknown" when no region subtag is present.
+ */
+export const localeToCountry = (locale: string | null | undefined): string => {
+  if (!locale) return "Unknown";
+
+  // Take the highest-priority language tag and pull its region subtag.
+  const primary = locale.split(",")[0]?.trim() ?? "";
+  const parts = primary.split("-");
+  const region = parts.length > 1 ? parts[parts.length - 1] : "";
+
+  if (!region || !/^[A-Za-z]{2}$/.test(region)) return "Unknown";
+
+  const code = region.toUpperCase();
+  try {
+    return regionDisplay?.of(code) ?? code;
+  } catch {
+    return code;
+  }
+};
+
+/**
+ * Turn a raw referrer URL into a readable source label. Empty referrers are
+ * "Direct"; otherwise we show the hostname (e.g. "google.com").
+ */
+export const formatReferrer = (referrer: string | null | undefined): string => {
+  if (!referrer) return "Direct";
+  try {
+    return new URL(referrer).hostname || "Direct";
+  } catch {
+    return referrer;
+  }
+};


### PR DESCRIPTION
## Summary

Two related changes to `/home/dashboard`:

### 1. Wire mocked dashboard panels to real data (`feat(dashboard)`)
Previously several panels rendered hardcoded mock arrays. They now pull live, user-scoped data:

- **Device Usage**, **Scan Locations**, **Recent Scan Activity** — derived from `QrCodeController` rows (user-agent / accept-language / referrer parsed at query time via a new `scan-analytics.utils`).
- **Your QR Codes** grid/list — the user's real QR codes with live scan counts, plus working **search**, **type filter**, **CSV export**, and **edit / copy-link / delete** actions.
- **Scan Activity** period selector now actually drives the chart (7d / 30d / 90d / year).

New JStack queries: `getQrCodesWithScans`, `getRecentScans`, `getDeviceUsage`, `getScanLocations`. No DB schema/migration needed — everything derives from existing columns.

Also fixes `getQrCodeStats` mutating `now` while computing week bounds, which corrupted the month-over-month comparison windows.

### 2. Enforce per-user data isolation (`fix(api)`)
Audit of how the routers read from the DB surfaced a cross-user exposure vector:

- All authenticated queries scope by `auth?.session?.user.id!`. The `!` is compile-time only — if `user.id` were ever `undefined`, Prisma **drops** `where: { userId: undefined }` and returns **all users' rows**. `authMiddleware` now requires a resolved `session.user.id` and **fails closed (401)**, guaranteeing a concrete id for every scoped query.
- `controller.delete` wasn't scoped to the caller at all (`userId: (input.id, input.id)!` — a comma-operator typo). Switched to a `deleteMany` scoped by the owning `qrCode.userId`, so a user can only delete their own scan records.

## Test plan
- `bun run build` passes (compile + types + lint, all routes generated).
- Dashboard panels show proper empty states until controlled QR codes are scanned.

## Notes
- Location granularity is country-level (inferred from `accept-language`); no GeoIP is stored.
- Scan-derived panels populate only once **controlled** QR codes are scanned (that's when `QrCodeController` rows are created).

🤖 Generated with [Claude Code](https://claude.com/claude-code)